### PR TITLE
Added intercept and wait for table tests:

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,4 +37,4 @@ jobs:
         run: npm ci
 
       - name: Run Cypress tests
-        run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --env ${{ secrets.CYPRESS_ENV }} --parallel --browser chrome
+        run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --env ${{ secrets.CYPRESS_ENV }} --parallel --browser edge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,4 +37,4 @@ jobs:
         run: npm ci
 
       - name: Run Cypress tests
-        run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --env ${{ secrets.CYPRESS_ENV }} --parallel
+        run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --env ${{ secrets.CYPRESS_ENV }} --parallel --browser chrome

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,4 +37,4 @@ jobs:
         run: npm ci
 
       - name: Run Cypress tests
-        run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --env ${{ secrets.CYPRESS_ENV }} --parallel --browser edge
+        run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --env ${{ secrets.CYPRESS_ENV }} --parallel

--- a/cypress/e2e/Portal/Accounts/account-list.cy.js
+++ b/cypress/e2e/Portal/Accounts/account-list.cy.js
@@ -20,8 +20,10 @@ describe("account list", () => {
 
     //filters account by customer
     cy.get('[data-qa="input.filter"]').click();
+    cy.intercept('**/internal-api/paginate/account**').as('tableAccountRequest');
     cy.get('div[class*="v-list-item"]').contains('Customer').as('listCustomer');
     cy.get('@listCustomer').click();
+    cy.wait('@tableAccountRequest', {timeout: 30000});
     tableContains('Type', 'Customer', 'Error when filtering by account type');
     tableRegex('Create Date', YYYYMMDD, 'Error: date does not match yyyy-mm-dd format');
     //checks first data records action buttons

--- a/cypress/e2e/Portal/Generic/commissioning.cy.js
+++ b/cypress/e2e/Portal/Generic/commissioning.cy.js
@@ -55,7 +55,9 @@ describe("commissions", () => {
             const text = $div.text();
             const num = Number(text);
 
+            cy.intercept('**/internal-api/paginate/commission**').as('completedRequest');
             cy.get('[data-qa="checkbox.completed"]').parent().click();
+            cy.wait('@completedRequest', {timeout: 30000});
 
             cy.get('div[class="v-data-footer__pagination"]').then(($div2) => {
 
@@ -75,8 +77,9 @@ describe("commissions", () => {
 
             const text = $div.text();
             const num = Number(text);
-
+            cy.intercept('**/internal-api/paginate/commission**').as('deletedRequest');
             cy.get('[data-qa="checkbox.deleted"]').parent().click();
+            cy.wait('@deletedRequest', {timeout: 30000});
 
             cy.get('div[class="v-data-footer__pagination"]').then(($div2) => {
 

--- a/cypress/e2e/Portal/Systems/EVC/evc-list.cy.js
+++ b/cypress/e2e/Portal/Systems/EVC/evc-list.cy.js
@@ -26,14 +26,18 @@ describe("my evc page", () => {
         tableRegex("Online Since", dateAndTime, "Error: last updated is showing incorrect date format, should be YYYY-MM-DD HH:MM:SS");
 
         cy.get('[data-qa="autocomplete.status"]').should('be.visible');
+        cy.intercept('**/internal-api/paginate/ev-charger**').as('statusRequest');
         cy.get('[data-qa="autocomplete.status"]').click();
         cy.get('div[class*="v-list-item"]').contains('Available').click();
+        cy.wait('@statusRequest', {timeout: 30000});
         cy.wait(2000);
         tableContains("Status", "Available", "Error: filtering by status did not work");
 
         cy.get('[data-qa="autocomplete.product"]').should('be.visible');
+        cy.intercept('**/internal-api/paginate/ev-charger**').as('productRequest');
         cy.get('[data-qa="autocomplete.product"]').click();
         cy.get('div[class*="v-list-item"]').contains('SingleSocketCharger (WWWW)').click();
+        cy.wait('@productRequest', {timeout: 30000});
         tableContains("Product", "SingleSocketCharger", "Error: filtering by product did not work");
 
     });

--- a/cypress/e2e/Portal/Systems/EVC/my-ev-charger.cy.js
+++ b/cypress/e2e/Portal/Systems/EVC/my-ev-charger.cy.js
@@ -262,13 +262,17 @@ describe("ev charger", () => {
             const value = $el.text();
 
             if (value === "Logs") {
+                cy.intercept('**/internal-api/paginate/ev-charger-command-record?page=1&itemsPerPage=15').as('logsRequest');
                 cy.get('div[class="v-tab"]').last().click();
+                cy.wait('@logsRequest', {timeout: 30000});
                 cy.get('[data-qa="table"]').should('be.visible');
                 cy.get('[data-qa="search.user"]').should('be.enabled');
+                cy.intercept('**/internal-api/paginate/ev-charger-command-record?page=1&itemsPerPage=15').as('logsRequest');
                 cy.get('[data-qa="autocomplete.command"]').click();
                 cy.get('[data-qa="autocomplete.command"]').type('{downArrow}');
                 cy.get('[data-qa="autocomplete.command"]').type('{downArrow}');
                 cy.get('[data-qa="autocomplete.command"]').type('{enter}');
+                cy.wait('@logsRequest', {timeout: 30000});
                 tableContains("Setting", "Change Active Schedule", "Error: filtering by command did not work");
                 tableRegex("Time", dateAndTime, "Error: date and time format in time column does not match format YYYY-MM-DD HH:MM:SS");
 

--- a/cypress/e2e/Portal/Systems/batteries-list.cy.js
+++ b/cypress/e2e/Portal/Systems/batteries-list.cy.js
@@ -21,7 +21,9 @@ describe("my inverter page", () => {
         //creates alias for dashboard API request
         cy.intercept('**/staging.givenergy.cloud/dashboard').as('dashboardAPI');
         //opens my inverters and reloads page to hide nav bar
+        cy.intercept('**/staging.givenergy.cloud/batteries').as('batteriesAPI');
         dashboardSelect('My Batteries');
+        cy.wait('@batteriesAPI', {timeout: 30000});
         cy.get('[data-qa="search"]').should('be.visible').click();
         cy.get('[data-qa="title"]').should('be.visible').contains('My Batteries');
 
@@ -40,14 +42,16 @@ describe("my inverter page", () => {
         tableRegex("Cell #", positiveNumber, "Error: cell # is not a positive number");
         tableRegex("Cycle Count", positiveNumber, "Error: cycle count is not a positive number");
 
+        cy.intercept('**//internal-api/paginate/battery?page=1&itemsPerPage=15').as('capacityRequest');
         cy.get('[data-qa="autocomplete.capacity"]').should('be.visible');
         cy.get('[data-qa="autocomplete.capacity"]').click();
         cy.get('div[class*="v-list-item"]').contains('186Ah').click();
         cy.get('[data-qa="search"]').should('be.visible').click();
-        cy.wait(2000);
+        cy.wait('@capacityRequest', {timeout: 30000});
         tableContains("Design Capacity (Ah)", "186", "Error: filtering by design capacity did not work");
 
         cy.get('[data-qa="autocomplete.firmware"]').as('firmware');
+        cy.intercept('**//internal-api/paginate/battery?page=1&itemsPerPage=15').as('firmwareRequest');
         cy.get('@firmware').should('be.visible');
         cy.get('@firmware').click();
         cy.get('@firmware').type('3013');
@@ -55,7 +59,7 @@ describe("my inverter page", () => {
         cy.get('@3013').scrollIntoView();
         cy.get('@3013').click();
         cy.get('[data-qa="search"]').should('be.visible').click();
-        cy.wait(2000);
+        cy.wait('@firmwareRequest', {timeout: 30000});
         tableContains("Firmware Version", "3013", "Error: filtering by firmware version did not work");
 
     });

--- a/cypress/e2e/Portal/Systems/inverter-list.cy.js
+++ b/cypress/e2e/Portal/Systems/inverter-list.cy.js
@@ -21,7 +21,9 @@ describe("my inverter page", () => {
     //creates alias for dashboard API request
     cy.intercept('**/staging.givenergy.cloud/dashboard').as('dashboardAPI');
     //opens my inverters and reloads page to hide nav bar
+    cy.intercept('**/staging.givenergy.cloud/inverter').as('inverterAPI');
     dashboardSelect('My Inverters');
+    cy.wait('@inverterAPI');
     cy.get('[data-qa="title.text"]').contains('My Inverters');
     cy.get('[data-qa="search"]').click();
     
@@ -29,9 +31,11 @@ describe("my inverter page", () => {
     checkPageNav();
 
     //check filters
+    cy.intercept('**/internal-api/paginate/inverter?page=1&itemsPerPage=15').as('modelRequest');
     cy.get('[data-qa="auto.model"]').as('model');
     cy.get('@model').type('{downArrow}');
     cy.get('@model').type('{enter}');
+    cy.wait('@modelRequest');
     tableContains('Model', 'GIV-HY5.0', 'Error when filtering by inverter model')
     cy.get('[data-qa="title.text"]').contains('My Inverters').click();
 

--- a/cypress/funcs.js
+++ b/cypress/funcs.js
@@ -494,11 +494,13 @@ export function checkWarranty(headingIndex, tableDataIndex) {
     //checks existing warranty type and checks the other types
     //if 1st data record has no warranty showing then it increments tableDataIndex and calls itself
     //if tableDataIndex > 3 test will fail
+    cy.intercept('**/internal-api/paginate/inverter?page=1&itemsPerPage=15').as('modelRequest');
     cy.get('[data-qa="auto.model"]').as('model');
     cy.get('@model').type('{downArrow}');
     cy.get('@model').type('{downArrow}');
     cy.get('@model').type('{downArrow}');
     cy.get('@model').type('{enter}');
+    cy.wait('@modelRequest');
     cy.get('[data-qa="field.search"]').click();
     cy.get('[data-qa="table"]').find('tr').eq(tableDataIndex).find('td').eq(headingIndex).then(($td) => {
 
@@ -510,19 +512,23 @@ export function checkWarranty(headingIndex, tableDataIndex) {
             cy.get('[data-qa="main.navbar"]').children().eq(0).click();
             cy.get('[data-qa="main.navbar"]').contains('My Inverters').click();
 
+            cy.intercept('**/internal-api/paginate/inverter?page=1&itemsPerPage=15').as('modelRequest');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{enter}');
+            cy.wait('@modelRequest');
             cy.get('[data-qa="field.search"]').click();
             updateWarrantyAndCheck('Twelve years', 12, tableDataIndex);
             cy.get('[data-qa="main.navbar"]').children().eq(0).click();
             cy.get('[data-qa="main.navbar"]').contains('My Inverters').click();
 
+            cy.intercept('**/internal-api/paginate/inverter?page=1&itemsPerPage=15').as('modelRequest');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{enter}');
+            cy.wait('@modelRequest');
             cy.get('[data-qa="field.search"]').click();
             updateWarrantyAndCheck('Standard', 5, tableDataIndex);
 
@@ -532,19 +538,23 @@ export function checkWarranty(headingIndex, tableDataIndex) {
             cy.get('[data-qa="main.navbar"]').children().eq(0).click();
             cy.get('[data-qa="main.navbar"]').contains('My Inverters').click();
 
+            cy.intercept('**/internal-api/paginate/inverter?page=1&itemsPerPage=15').as('modelRequest');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{enter}');
+            cy.wait('@modelRequest');
             cy.get('[data-qa="field.search"]').click();
             updateWarrantyAndCheck('Twelve years', 12, tableDataIndex);
             cy.get('[data-qa="main.navbar"]').children().eq(0).click();
             cy.get('[data-qa="main.navbar"]').contains('My Inverters').click();
 
+            cy.intercept('**/internal-api/paginate/inverter?page=1&itemsPerPage=15').as('modelRequest');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{enter}');
+            cy.wait('@modelRequest');
             cy.get('[data-qa="field.search"]').click();
             updateWarrantyAndCheck('Extended', 10, tableDataIndex);
 
@@ -554,19 +564,23 @@ export function checkWarranty(headingIndex, tableDataIndex) {
             cy.get('[data-qa="main.navbar"]').children().eq(0).click();
             cy.get('[data-qa="main.navbar"]').contains('My Inverters').click();
 
+            cy.intercept('**/internal-api/paginate/inverter?page=1&itemsPerPage=15').as('modelRequest');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{enter}');
+            cy.wait('@modelRequest');
             cy.get('[data-qa="field.search"]').click();
             updateWarrantyAndCheck('Extended', 10, tableDataIndex);
             cy.get('[data-qa="main.navbar"]').children().eq(0).click();
             cy.get('[data-qa="main.navbar"]').contains('My Inverters').click();
 
+            cy.intercept('**/internal-api/paginate/inverter?page=1&itemsPerPage=15').as('modelRequest');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{downArrow}');
             cy.get('@model').type('{enter}');
+            cy.wait('@modelRequest');
             cy.get('[data-qa="field.search"]').click();
             updateWarrantyAndCheck('Twelve years', 12, tableDataIndex);
 


### PR DESCRIPTION
for tests where it loads a table or filters the results within the table it will use an intercept command to intercept the request to get the table data and then will perform a wait request for this request to be completed. This ensures the commands that evaluate the table do not run until the table is populated with the necessary data