### PR TITLE
Refactored rewards point test:

### DIFF
--- a/cypress/e2e/Portal/Admin Dashboard/reward-points.cy.js
+++ b/cypress/e2e/Portal/Admin Dashboard/reward-points.cy.js
@@ -129,7 +129,13 @@ describe("reward points", () => {
                 console.log(heading)
                 if (heading === "Via") {
                     for (var i = 1; i < numberOfRecords; i++) {
-                        cy.get('@table').find('tr').eq(i).find('td').eq(index).find('a[href*="/commission/"]');
+                        cy.get('@table').find('tr').eq(i).find('td').eq(index).then(($td) => {
+                            const value = $td.text();
+
+                            if (value === "Commission") {
+                                cy.get('@table').find('tr').eq(i).find('td').eq(index).find('a[href*="/commission/"]');
+                            }
+                        })
                     }
                 }
             });


### PR DESCRIPTION
as via can contain data that is not a commissions link a check has been added to deal with this case to prevent the test from failing